### PR TITLE
set the default of `portalContainer` to `document.body`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ The `ReactMouseSelect` component accepts a few props:
   Container ref in which selecting should work
 
 
-* `portalContainer`  [required]:<br/>
-  Portal container in which the highlighting frame will be rendered
+* `portalContainer` _default = document.body_:<br/>
+  Portal container in which the highlighting frame will be rendered.
 
 
 * `sensitivity` (number) _default = 10_:<br/>

--- a/src/reactMouseSelect.tsx
+++ b/src/reactMouseSelect.tsx
@@ -20,7 +20,7 @@ export const ReactMouseSelect = ({
   containerRef,
   sensitivity = 10,
   tolerance = 0,
-  portalContainer,
+  portalContainer = document.body,
   edgeSize = 100,
   onClickPreventDefault = false,
   notStartWithSelectableElements = false,


### PR DESCRIPTION
Not only because `document.body` is the default element used in [react-dom's createPortal usage example](https://react.dev/reference/react-dom/createPortal#usage), but because it's simpler and easier, anyone having anything against using `document.body` could change it to whatever they wanted using the now optional `portalContainer` prop.

Awesome library, by the way, works flawlessly! :)