### PR TITLE
Make portalContainer optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface ReactMouseSelectProps {
   /**
    * Portal container in which the highlighting frame will be rendered
    */
-  portalContainer: HTMLElement;
+  portalContainer?: HTMLElement;
 
   /**
    * Sensitivity in pixels


### PR DESCRIPTION
Unfortunately I missed this in https://github.com/andreizanik/react-mouse-select/pull/3